### PR TITLE
Stop distributing development files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+CHATBOT.txt export-ignore
+benchmarks/ export-ignore
+composer.lock export-ignore
+docs/ export-ignore
+examples/ export-ignore
+phpunit.xml export-ignore
+test.php export-ignore
+tests/ export-ignore


### PR DESCRIPTION
Command to test: `git archive HEAD | tar --list --exclude='*/*'` (runs on POSIX-compatible systems)