### PR TITLE
Update phasync.php

### DIFF
--- a/phasync.php
+++ b/phasync.php
@@ -11,7 +11,6 @@ use phasync\Internal\Subscribers;
 use phasync\Internal\ReadChannel;
 use phasync\Internal\WriteChannel;
 use phasync\ReadChannelInterface;
-use phasync\ReadSelectableInterface;
 use phasync\SelectableInterface;
 use phasync\TimeoutException;
 use phasync\Util\WaitGroup;
@@ -370,7 +369,7 @@ final class phasync {
      * 
      * @param SelectableInterface[] $selectables 
      * @param null|float $timeout 
-     * @return ReadSelectableInterface 
+     * @return SelectableInterface 
      * @throws LogicException 
      * @throws FiberError 
      * @throws Throwable 


### PR DESCRIPTION
ReadSelectableInterface does not exist and is being used in phpdoc as a return from the select method instead of SelectableInterface